### PR TITLE
cast fields to the right value_type

### DIFF
--- a/mogo/field.py
+++ b/mogo/field.py
@@ -68,9 +68,12 @@ class Field(object):
     def __set__(self, instance, value):
         value_type = type(value)
         if not self._check_value_type(value):
-            raise TypeError("Invalid type %s instead of %s" %
-                (value_type, self.value_type)
-            )
+            try:
+                value = self.value_type(value)
+            except:
+                raise TypeError("Invalid type %s instead of %s" %
+                    (value_type, self.value_type)
+                )
         if self._set_callback:
             value = self._set_callback(value)
         field_name = self._get_field_name(instance)

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -22,6 +22,7 @@ class MogoFieldTests(unittest.TestCase):
             required = Field(required=True)
             string = Field(basestring)
             reference = ReferenceField(Base)
+            number = Field(float)
 
         mock = MockModel()
         # checks if it is in the model fields (shouldn't be yet)
@@ -29,14 +30,16 @@ class MogoFieldTests(unittest.TestCase):
 
         # NOW we set up fields.
         cls_dict = MockModel.__dict__
-        field_names = ["typeless", "required", "field", "string"]
+        field_names = ["typeless", "required", "field", "string", "number"]
         MockModel._fields = dict([(cls_dict[v].id, v) for v in field_names])
         self.assertEqual(mock.field, None)
 
         mock.field = u"testing"
         self.assertEqual(mock.field, "testing")
         self.assertEqual(mock["field"], "testing")
-        self.assertRaises(TypeError, setattr, mock, "field", 5)
+        mock.number = 5
+        self.assertRaises(TypeError, setattr, mock, "number", {})
+        self.assertEqual(mock.number, 5)
         mock.required = u"testing"
         self.assertEqual(mock["required"], "testing")
 


### PR DESCRIPTION
I'm porting snoball from nod's mogo to this mogo. Nod's fork of mogo did not do any validation of value_type, so we have a several fields that get assigned both floats and ints. I think it'd be good to still validate that it is a number.

If the isinstance check fails, this patch sends value to value_type's constructor. This does something reasonable for most built-in types: Field(list) will turn any iterable object into a list, Field(float) will turn ints into floats, and Field(unicode) will convert strs to unicode.
