### PR TITLE
added FloatField

### DIFF
--- a/mogo/__init__.py
+++ b/mogo/__init__.py
@@ -1,7 +1,8 @@
 """ This is the mogo syntactic sugar library for MongoDB. """
 
 from mogo.model import Model, PolyModel
-from mogo.field import Field, ReferenceField, ConstantField, EnumField
+from mogo.field import Field, ReferenceField, ConstantField, EnumField, \
+                       FloatField
 from mogo.cursor import ASC, DESC
 from mogo.connection import connect, session
 
@@ -10,4 +11,5 @@ from mogo.connection import connect, session
 AUTO_CREATE_FIELDS = False
 
 __all__ = ['Model', 'PolyModel', 'Field', 'ReferenceField', "ConstantField",
-    "EnumField", 'connect', 'session', 'ASC', 'DESC', "AUTO_CREATE_FIELDS"]
+    "EnumField", "FloatField", 'connect', 'session', 'ASC', 'DESC',
+    "AUTO_CREATE_FIELDS"]

--- a/mogo/field.py
+++ b/mogo/field.py
@@ -124,6 +124,14 @@ class ConstantField(Field):
         return value
 
 
+class FloatField(Field):
+    def _set_callback(self, instance, value):
+        """ Checks that value can become a float or raises ValueError. """
+        if value is None:
+            return value
+        return float(value)
+
+
 class EnumField(Field):
     """ Only accepts values from a set / list of values.
     The first argument should be an iterable with acceptable values, or

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -5,7 +5,7 @@ in mogo Fields.
 
 import unittest
 import warnings
-from mogo import Field, ReferenceField, connect, Model, EnumField
+from mogo import Field, ReferenceField, connect, Model, EnumField, FloatField
 from mogo.field import EmptyRequiredField
 
 class Base(object):
@@ -139,6 +139,24 @@ class MogoFieldTests(unittest.TestCase):
         EnumModel2(field="EnumModel2")
         with self.assertRaises(ValueError):
             EnumModel1(field="nottheclassname")
+
+    def test_float_field(self):
+        """ Test the float field """
+        class FloatModel(Model):
+            boring = FloatField()
+            seven = FloatField(default=7)
+            required = FloatField(required=True)
+
+        instance = FloatModel(required=2.5)
+        self.assertEqual(instance.required, 2.5)
+        self.assertEqual(instance.seven, 7)
+        self.assertEqual(instance.boring, None)
+
+        with self.assertRaises(ValueError):
+            instance = FloatModel(required="123a")
+
+        instance = FloatModel(required=1)
+        self.assertEqual(instance.required, 1)
 
     def test_default_field(self):
         """ Test that the default behavior works like you'd expect. """


### PR DESCRIPTION
This creates a field that you can assign ints or floats to.

It might make sense to have a CastingField that casts to value_type on assignment, but that would involve overriding `__set__` and not just `_set_callback` .
