### PR TITLE
Freezes PyMongo version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
     url="http://github.com/joshmarshall/mogo/",
     license="http://www.apache.org/licenses/LICENSE-2.0",
     packages=['mogo', ],
-    install_requires=['pymongo', ]
+    install_requires=['pymongo==2.8.1', ]
 )


### PR DESCRIPTION
* Added pymongo==2.8.1 to setup.py. #14
* Latest version of `pymongo` that avoids `ImportError` in #20.
* All nose tests pass.