### PR TITLE
convenience __len__ added to cursor

### DIFF
--- a/mogo/cursor.py
+++ b/mogo/cursor.py
@@ -26,6 +26,10 @@ class Cursor(PyCursor):
         value = PyCursor.next(self)
         return self._model(**value)
 
+    # convenient because if it quacks like a list...
+    def __len__(self):
+        return self.count()
+
     def __getitem__(self, *args, **kwargs):
         value = PyCursor.__getitem__(self, *args, **kwargs)
         if type(value) == self.__class__:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -249,6 +249,15 @@ class MogoTests(unittest.TestCase):
         for f in result:
             self.assertTrue(type(f) is Foo)
 
+    def test_find_len(self):
+        foo = Foo(bar=u'find')
+        foo.save(safe=True)
+        foo2 = Foo(bar=u'find')
+        foo2.save()
+        result = Foo.find({'bar': u'find'})
+        self.assertTrue(result.count() == 2)
+        self.assertTrue(len(result) == 2)
+
     def test_bad_find(self):
         foo = Foo.new(bar=u'bad_find')
         foo.save(safe=True)


### PR DESCRIPTION
Cursors have a simplistic list like access by index, but no `__len__` method.