### PR TITLE
Make default values not shareable if dict or list is used

### DIFF
--- a/mogo/field.py
+++ b/mogo/field.py
@@ -1,6 +1,7 @@
 """ The basic field attributes. """
 
 import warnings
+from copy import deepcopy
 
 # PyMongo moving libraries around -- eventually this can
 # go away.
@@ -73,7 +74,11 @@ class Field(object):
             return
         if hasattr(self, "default"):
             if not callable(self.default):
-                default_value = self.default
+                if (isinstance(self.default, dict)
+                        or isinstance(self.default, list)):
+                    default_value = deepcopy(self.default)
+                else:
+                    default_value = self.default
             else:
                 default_value = self.default()
             setattr(model, field, default_value)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,6 +27,8 @@ class Foo(Model):
     field = Field()
     required = Field(required=True)
     default = Field(default="default")
+    defaultDict = Field(default={})
+    defaultList = Field(default=[])
     callback = Field(get_callback=lambda x, y: "foo",
                      set_callback=lambda x, y: "bar")
     reference = ReferenceField(Ref)
@@ -180,3 +182,11 @@ class MogoTestModel(unittest.TestCase):
         self.assertFalse(infant.walk())
         infant2 = Person(age=3, role=u"infant")
         self.assertIsInstance(infant2, Infant)
+
+    def test_non_shared_defaults(self):
+        f1 = Foo()
+        f1.defaultDict['a'] = 1
+        f1.defaultList.append(0)
+        f2 = Foo()
+        self.assertTrue('a' not in f2.defaultDict)
+        self.assertEqual(len(f2.defaultList), 0)


### PR DESCRIPTION
Hello,

Noticed a nasty behaviour of default Field values when used with lists or dicts.
Please see tests.